### PR TITLE
Use correlation IDs to enable connection sharing

### DIFF
--- a/lib/bunny_burrow/client.rb
+++ b/lib/bunny_burrow/client.rb
@@ -1,14 +1,11 @@
 require_relative 'base'
+require 'securerandom'
 
 module BunnyBurrow
   class Client < Base
     def publish(payload, routing_key)
       result = nil
-
-      # when creating a queue, a blank name indicates we want the AMPQ broker
-      # to generate a unique name for us. Also note that this queue will be on
-      # the default exchange
-      reply_to = channel.queue('', exclusive: true, auto_delete: true)
+      correlation_id = SecureRandom::uuid
 
       details = {
         routing_key: routing_key,
@@ -20,25 +17,35 @@ module BunnyBurrow
       options = {
         routing_key: routing_key,
         reply_to: reply_to.name,
-        persistence: false
+        persistence: false,
+        correlation_id: correlation_id
       }
 
       topic_exchange.publish(payload.to_json, options)
 
       Timeout.timeout(timeout) do
-        reply_to.subscribe do |_, _, payload|
-          details[:response] = payload if log_response?
-          log "Receiving #{details}"
-          result = payload
-          lock.synchronize { condition.signal }
+        reply_to.subscribe do |_, properties, payload|
+          if properties[:correlation_id] == correlation_id
+            details[:response] = payload if log_response?
+            log "Receiving #{details}"
+            result = payload
+            lock.synchronize { condition.signal }
+          end
         end
 
         lock.synchronize { condition.wait(lock) }
       end
 
        result
-    ensure
-      reply_to.delete if reply_to
+    end
+
+    private
+
+    def reply_to
+      # when creating a queue, a blank name indicates we want the AMPQ broker
+      # to generate a unique name for us. Also note that this queue will be on
+      # the default exchange
+      @reply_to ||= channel.queue('', exclusive: true, auto_delete: true)
     end
   end
 end

--- a/lib/bunny_burrow/version.rb
+++ b/lib/bunny_burrow/version.rb
@@ -1,3 +1,3 @@
 module BunnyBurrow
-  VERSION = '1.5.2'
+  VERSION = '1.5.3'
 end


### PR DESCRIPTION
Making and deleting a reply-to queue for each request is inefficient.  Using a single queue per client and using correlation IDs to match requests to responses is better.